### PR TITLE
Change runeLiteVersion from latest.release to 1.10.8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = 'latest.release'
+def runeLiteVersion = '1.10.8.2'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion


### PR DESCRIPTION
For some reason I kept getting the error that the RuneLite client was outdated.